### PR TITLE
Fixed CI build

### DIFF
--- a/client-shared-js/.babelrc
+++ b/client-shared-js/.babelrc
@@ -1,11 +1,12 @@
 {
-    "presets": [
-        [
-            "@babel/preset-env",
-            {
-                "modules": "umd"
-            }
-        ]
-    ],
-    "moduleId": "ClientShared"
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "modules": "umd"
+      }
+    ]
+  ],
+  "plugins": ["@babel/plugin-syntax-import-meta"],
+  "moduleId": "ClientShared"
 }

--- a/client-shared-js/package.json
+++ b/client-shared-js/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@babel/cli": "7.4.4",
     "@babel/core": "7.4.5",
+    "@babel/plugin-syntax-import-meta": "7.2.0",
     "@babel/preset-env": "7.4.5",
     "babel-preset-minify": "0.5.0"
   }

--- a/client-web-webpack/package.json
+++ b/client-web-webpack/package.json
@@ -13,6 +13,7 @@
     "source-map-loader": "^0.2.3"
   },
   "devDependencies": {
+    "@open-wc/webpack-import-meta-loader": "0.2.4",
     "@types/knockout": "3.4.66",
     "@types/node": "12.0.2",
     "@types/react": "16.8.18",
@@ -26,7 +27,8 @@
     "style-loader": "0.23.1",
     "ts-node": "8.2.0",
     "typescript": "3.4.5",
-    "webpack": "4.32.2"
+    "webpack": "4.32.2",
+    "webpack-cli": "3.3.5"
   },
   "scripts": {
     "build": "webpack",

--- a/client-web-webpack/webpack.config.ts
+++ b/client-web-webpack/webpack.config.ts
@@ -1,70 +1,79 @@
 import * as webpack from "webpack";
 
 const config: webpack.Configuration = {
-    entry: {
-        knockout: "./knockout/index.ts",
-        react: "./react/index.tsx"
-    },
-    output: {
-        filename: "[name].js",
-        path: __dirname + "/dist",
-        publicPath: "/dist/"
-    },
-    node: {
-        fs: "empty"
-    },
+  entry: {
+    knockout: "./knockout/index.ts",
+    react: "./react/index.tsx"
+  },
+  output: {
+    filename: "[name].js",
+    path: __dirname + "/dist",
+    publicPath: "/dist/"
+  },
+  node: {
+    fs: "empty"
+  },
 
-    // Enable sourcemaps for debugging webpack's output.
-    devtool: "source-map",
+  // Enable sourcemaps for debugging webpack's output.
+  devtool: "source-map",
 
-    resolve: {
-        // Add '.ts' and '.tsx' as resolvable extensions.
-        extensions: [".ts", ".tsx", ".js", ".json", ".html", ".js.mem"]
-    },
+  resolve: {
+    // Add '.ts' and '.tsx' as resolvable extensions.
+    extensions: [".ts", ".tsx", ".js", ".json", ".html", ".js.mem"]
+  },
 
-    module: {
-        rules: [
-            // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'.
-            { test: /\.tsx?$/, loader: "awesome-typescript-loader" },
+  module: {
+    rules: [
+      // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'.
+      { test: /\.tsx?$/, loader: "awesome-typescript-loader" },
 
-            // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
-            { enforce: "pre", test: /\.js$/, loader: "source-map-loader" },
+      // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
+      { enforce: "pre", test: /\.js$/, loader: "source-map-loader" },
 
-            // All scss files
-            {
-                test: /\.scss$/,
-                use: [{
-                    loader: "style-loader" // creates style nodes from JS strings
-                }, {
-                    loader: "css-loader" // translates CSS into CommonJS
-                }, {
-                    loader: "sass-loader" // compiles Sass to CSS
-                }]
-            },
-
-            // Knockout Only
-            // HTML files for knockout templates
-            {
-                test: /\.html$/,
-                exclude: /node_modules/,
-                loader: "html-loader?exportAsEs6Default"
-            }
+      // All scss files
+      {
+        test: /\.scss$/,
+        use: [
+          {
+            loader: "style-loader" // creates style nodes from JS strings
+          },
+          {
+            loader: "css-loader" // translates CSS into CommonJS
+          },
+          {
+            loader: "sass-loader" // compiles Sass to CSS
+          }
         ]
-    },
+      },
 
-    // When importing a module whose path matches one of the following, just
-    // assume a corresponding global variable exists and use that instead.
-    // This is important because it allows us to avoid bundling all of our
-    // dependencies, which allows browsers to cache those libraries between builds.
-    externals: {
-        // React Only
-        "react": "React",
-        "react-dom": "ReactDOM"
-    },
+      // Knockout Only
+      // HTML files for knockout templates
+      {
+        test: /\.html$/,
+        exclude: /node_modules/,
+        loader: "html-loader?exportAsEs6Default"
+      },
 
-    plugins: [
-        new webpack.HotModuleReplacementPlugin(),
+      // Add the meta loader (currently stage 3)
+      // https://github.com/webpack/webpack/issues/6719
+      {
+        test: /\.js$/,
+        loader: require.resolve("@open-wc/webpack-import-meta-loader")
+      }
     ]
+  },
+
+  // When importing a module whose path matches one of the following, just
+  // assume a corresponding global variable exists and use that instead.
+  // This is important because it allows us to avoid bundling all of our
+  // dependencies, which allows browsers to cache those libraries between builds.
+  externals: {
+    // React Only
+    react: "React",
+    "react-dom": "ReactDOM"
+  },
+
+  plugins: [new webpack.HotModuleReplacementPlugin()]
 };
 
 export default config;


### PR DESCRIPTION
Issue is a new version of emscripten depends on import.meta.url which isn't currently available in Babel without a plugin